### PR TITLE
feat: ajouter des fonctions d'aide pour les réponses HTTP

### DIFF
--- a/app/lib/core/infrastructure/http_client_helpers.dart
+++ b/app/lib/core/infrastructure/http_client_helpers.dart
@@ -1,0 +1,5 @@
+bool isResponseSuccessful(final int? statusCode) =>
+    statusCode != null && statusCode >= 200 && statusCode < 300;
+
+bool isResponseUnsuccessful(final int? statusCode) =>
+    !isResponseSuccessful(statusCode);

--- a/app/lib/features/actions/detail/infrastructure/action_repository.dart
+++ b/app/lib/features/actions/detail/infrastructure/action_repository.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/core/infrastructure/message_bus.dart';
 import 'package:app/features/actions/core/domain/action_id.dart';
 import 'package:app/features/actions/core/domain/action_status.dart';
@@ -23,7 +22,7 @@ class ActionRepository {
       '/utilisateurs/{userId}/defis/${id.value}',
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? Right(ActionMapper.fromJson(response.data as Map<String, dynamic>))
         : Left(Exception('Erreur lors de la récupération des actions'));
   }
@@ -49,7 +48,7 @@ class ActionRepository {
     }
     final response = await _client.patch(path, data: data);
 
-    if (response.statusCode == HttpStatus.ok) {
+    if (isResponseSuccessful(response.statusCode)) {
       _messageBus.publish(actionCompletedTopic);
 
       return const Right(unit);

--- a/app/lib/features/actions/list/infrastructure/actions_adapter.dart
+++ b/app/lib/features/actions/list/infrastructure/actions_adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/actions/list/domain/action_item.dart';
 import 'package:app/features/actions/list/domain/actions_port.dart';
 import 'package:app/features/actions/list/infrastructure/action_item_mapper.dart';
@@ -17,7 +17,7 @@ class ActionsAdapter implements ActionsPort {
   Future<Either<Exception, List<ActionItem>>> fetchActions() async {
     final response = await _client.get('/utilisateurs/{userId}/defis');
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération des actions'));
     }
 

--- a/app/lib/features/aides/core/infrastructure/aides_api_adapter.dart
+++ b/app/lib/features/aides/core/infrastructure/aides_api_adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/aides/core/domain/aide.dart';
 import 'package:app/features/aides/core/domain/aides_port.dart';
 import 'package:app/features/aides/core/infrastructure/aide_mapper.dart';
@@ -17,7 +17,7 @@ class AidesApiAdapter implements AidesPort {
   Future<Either<Exception, List<Aide>>> fetchAides() async {
     final response = await _client.get('/utilisateurs/{userId}/aides');
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération des aides'));
     }
 

--- a/app/lib/features/articles/infrastructure/articles_api_adapter.dart
+++ b/app/lib/features/articles/infrastructure/articles_api_adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/articles/domain/article.dart';
 import 'package:app/features/articles/domain/articles_port.dart';
 import 'package:app/features/articles/infrastructure/article_mapper.dart';
@@ -39,8 +39,8 @@ class ArticlesApiAdapter implements ArticlesPort {
 
     final cmsResponse = responses.first;
     final apiResponse = responses[1];
-    if (cmsResponse.statusCode != HttpStatus.ok ||
-        apiResponse.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(cmsResponse.statusCode) ||
+        isResponseUnsuccessful(apiResponse.statusCode)) {
       return Left(Exception("Erreur lors de la récupération de l'article"));
     }
 
@@ -68,7 +68,7 @@ class ArticlesApiAdapter implements ArticlesPort {
       body: jsonEncode({'content_id': id, 'type': 'article_lu'}),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la validation du quiz'));
   }
@@ -85,7 +85,7 @@ class ArticlesApiAdapter implements ArticlesPort {
       body: jsonEncode({'content_id': id, 'type': 'article_favoris'}),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception("Erreur lors de l'ajout de l'article aux favoris"));
   }
@@ -102,7 +102,7 @@ class ArticlesApiAdapter implements ArticlesPort {
       body: jsonEncode({'content_id': id, 'type': 'article_non_favoris'}),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception("Erreur lors du retrait de l'article aux favoris"));
   }

--- a/app/lib/features/authentification/core/infrastructure/authentification_api_adapter.dart
+++ b/app/lib/features/authentification/core/infrastructure/authentification_api_adapter.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:app/core/error/domain/api_erreur.dart';
 import 'package:app/core/error/infrastructure/api_erreur_helpers.dart';
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentication/domain/authentication_service.dart';
 import 'package:app/features/authentification/core/domain/authentification_port.dart';
 import 'package:app/features/authentification/core/domain/information_de_code.dart';
@@ -36,7 +36,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
       }),
     );
 
-    if (response.statusCode == HttpStatus.created) {
+    if (isResponseSuccessful(response.statusCode)) {
       _connexionDemandee = true;
 
       return const Right(null);
@@ -78,7 +78,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
       }),
     );
 
-    return response.statusCode == HttpStatus.created
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : handleError(
             response.body,
@@ -95,7 +95,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
       body: jsonEncode({'email': email}),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la validation du code'));
   }
@@ -116,7 +116,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
       }),
     );
 
-    if (response.statusCode == HttpStatus.created) {
+    if (isResponseSuccessful(response.statusCode)) {
       _connexionDemandee = false;
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       final token = json['token'] as String;
@@ -139,7 +139,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
       body: jsonEncode({'email': email}),
     );
 
-    return response.statusCode == HttpStatus.created
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la demande de mot de passe oublié'));
   }
@@ -159,7 +159,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
       }),
     );
 
-    return response.statusCode == HttpStatus.created
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : handleError(
             response.body,
@@ -177,7 +177,7 @@ class AuthentificationApiAdapter implements AuthentificationPort {
     final response =
         await _apiClient.get(Uri.parse('/utilisateurs/$utilisateurId'));
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(
         Exception("Erreur lors de la récupération de l'utilisateur"),
       );

--- a/app/lib/features/bibliotheque/infrastructure/bibliotheque_api_adapter.dart
+++ b/app/lib/features/bibliotheque/infrastructure/bibliotheque_api_adapter.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/bibliotheque/domain/bibliotheque.dart';
 import 'package:app/features/bibliotheque/domain/bibliotheque_port.dart';
@@ -40,7 +40,7 @@ class BibliothequeApiAdapter implements BibliothequePort {
 
     final response = await _apiClient.get(uri);
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(
         Exception('Erreur lors de la récupération de la bibliothèque'),
       );

--- a/app/lib/features/communes/infrastructure/communes_api_adapter.dart
+++ b/app/lib/features/communes/infrastructure/communes_api_adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/communes/domain/communes_port.dart';
 import 'package:fpdart/fpdart.dart';
@@ -19,7 +19,7 @@ class CommunesApiAdapter implements CommunesPort {
     final response =
         await _apiClient.get(Uri.parse('/communes?code_postal=$codePostal'));
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? Right((jsonDecode(response.body) as List<dynamic>).cast())
         : Left(Exception('Erreur lors de la récupération des communes'));
   }

--- a/app/lib/features/first_name/infrastructure/first_name_adapter.dart
+++ b/app/lib/features/first_name/infrastructure/first_name_adapter.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:app/core/error/infrastructure/api_erreur_helpers.dart';
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/first_name/domain/first_name.dart';
 import 'package:app/features/first_name/domain/first_name_port.dart';
@@ -29,7 +29,7 @@ final class FirstNameAdapter implements FirstNamePort {
 
     final response = await _apiClient.patch(uri, body: body);
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(unit)
         : handleError(
             response.body,

--- a/app/lib/features/gamification/infrastructure/gamification_api_adapter.dart
+++ b/app/lib/features/gamification/infrastructure/gamification_api_adapter.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/core/infrastructure/message_bus.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/gamification/domain/gamification.dart';
@@ -33,7 +33,7 @@ class GamificationApiAdapter implements GamificationPort {
     final response = await _apiClient.get(
       Uri.parse('/utilisateurs/$utilisateurId/gamification'),
     );
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération des points'));
     }
 

--- a/app/lib/features/know_your_customer/list/infrastructure/know_your_customers_repository.dart
+++ b/app/lib/features/know_your_customer/list/infrastructure/know_your_customers_repository.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/dio_http_client.dart';
 import 'package:app/features/mieux_vous_connaitre/core/domain/question.dart';
 import 'package:app/features/mieux_vous_connaitre/core/infrastructure/question_mapper.dart';
@@ -13,7 +12,7 @@ class KnowYourCustomersRepository {
 
   Future<Either<Exception, List<Question>>> fetchQuestions() async {
     final response = await _client.get('/utilisateurs/{userId}/questionsKYC');
-    if (response.statusCode == HttpStatus.ok) {
+    if (isResponseSuccessful(response.statusCode)) {
       final data = response.data! as List<dynamic>;
 
       return Right(

--- a/app/lib/features/mieux_vous_connaitre/core/infrastructure/mieux_vous_connaitre_api_adapter.dart
+++ b/app/lib/features/mieux_vous_connaitre/core/infrastructure/mieux_vous_connaitre_api_adapter.dart
@@ -1,8 +1,8 @@
 // ignore_for_file: avoid-slow-collection-methods
 
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/dio_http_client.dart';
 import 'package:app/features/mieux_vous_connaitre/core/domain/mieux_vous_connaitre_port.dart';
 import 'package:app/features/mieux_vous_connaitre/core/domain/question.dart';
@@ -23,7 +23,7 @@ class MieuxVousConnaitreApiAdapter implements MieuxVousConnaitrePort {
       '/utilisateurs/{userId}/questionsKYC/$id',
     );
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération de la question'));
     }
 
@@ -57,7 +57,7 @@ class MieuxVousConnaitreApiAdapter implements MieuxVousConnaitrePort {
       data: jsonEncode(object),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la mise à jour des réponses'));
   }

--- a/app/lib/features/profil/core/infrastructure/profil_api_adapter.dart
+++ b/app/lib/features/profil/core/infrastructure/profil_api_adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/profil/core/domain/profil_port.dart';
 import 'package:app/features/profil/core/domain/utilisateur_id_non_trouve_exception.dart';
@@ -26,7 +26,7 @@ class ProfilApiAdapter implements ProfilPort {
     final response =
         await _apiClient.get(Uri.parse('/utilisateurs/$utilisateurId/profile'));
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération du profil'));
     }
 
@@ -71,7 +71,7 @@ class ProfilApiAdapter implements ProfilPort {
 
     final response = await _apiClient.patch(uri, body: body);
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la mise à jour du profil'));
   }
@@ -86,7 +86,7 @@ class ProfilApiAdapter implements ProfilPort {
     final response = await _apiClient
         .get(Uri.parse('/utilisateurs/$utilisateurId/logement'));
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération du logement'));
     }
 
@@ -109,7 +109,7 @@ class ProfilApiAdapter implements ProfilPort {
 
     final response = await _apiClient.patch(uri, body: body);
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la mise à jour du logement'));
   }
@@ -125,7 +125,7 @@ class ProfilApiAdapter implements ProfilPort {
 
     final response = await _apiClient.delete(uri);
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la suppression du compte'));
   }
@@ -144,7 +144,7 @@ class ProfilApiAdapter implements ProfilPort {
 
     final response = await _apiClient.patch(uri, body: body);
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la mise à jour du mot de passe'));
   }
@@ -164,7 +164,7 @@ class ProfilApiAdapter implements ProfilPort {
 
     final response = await _apiClient.patch(uri, body: body);
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(
             Exception(

--- a/app/lib/features/quiz/infrastructure/quiz_api_adapter.dart
+++ b/app/lib/features/quiz/infrastructure/quiz_api_adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/authentification/core/infrastructure/cms_api_client.dart';
 import 'package:app/features/profil/core/domain/utilisateur_id_non_trouve_exception.dart';
@@ -31,7 +31,7 @@ class QuizApiAdapter implements QuizPort {
       ),
     );
 
-    if (cmsResponse.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(cmsResponse.statusCode)) {
       return Left(Exception('Erreur lors de la récupération du quiz'));
     }
 
@@ -43,7 +43,7 @@ class QuizApiAdapter implements QuizPort {
       final articleResponse = await _apiClient.get(
         Uri.parse('utilisateurs/$utilisateurId/bibliotheque/articles/$id'),
       );
-      if (articleResponse.statusCode != HttpStatus.ok) {
+      if (isResponseUnsuccessful(articleResponse.statusCode)) {
         return Left(Exception("Erreur lors de la récupération de l'article"));
       }
       articleData = jsonDecode(articleResponse.body) as Map<String, dynamic>;
@@ -71,7 +71,7 @@ class QuizApiAdapter implements QuizPort {
       }),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la validation du quiz'));
   }

--- a/app/lib/features/recommandations/infrastructure/recommandations_api_adapter.dart
+++ b/app/lib/features/recommandations/infrastructure/recommandations_api_adapter.dart
@@ -1,8 +1,8 @@
 // ignore_for_file: no-equal-switch-expression-cases
 
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/profil/core/domain/utilisateur_id_non_trouve_exception.dart';
 import 'package:app/features/recommandations/domain/recommandation.dart';
@@ -35,7 +35,7 @@ class RecommandationsApiAdapter implements RecommandationsPort {
 
     final response = await _apiClient.get(uri);
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(
         Exception('Erreur lors de la récupération des recommandations'),
       );

--- a/app/lib/features/simulateur_velo/infrastructure/aide_velo_api_adapter.dart
+++ b/app/lib/features/simulateur_velo/infrastructure/aide_velo_api_adapter.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/dio_http_client.dart';
 import 'package:app/features/simulateur_velo/domain/aide_velo_par_type.dart';
 import 'package:app/features/simulateur_velo/domain/aide_velo_port.dart';
@@ -65,7 +66,7 @@ class AideVeloApiAdapter implements AideVeloPort {
     ]);
 
     for (final response in responses) {
-      if (response.statusCode != HttpStatus.ok) {
+      if (isResponseUnsuccessful(response.statusCode)) {
         return Left(Exception('Erreur lors de la mise à jour du profil'));
       }
     }

--- a/app/lib/features/univers/core/infrastructure/univers_api_adapter.dart
+++ b/app/lib/features/univers/core/infrastructure/univers_api_adapter.dart
@@ -1,8 +1,8 @@
 // ignore_for_file: no-equal-switch-expression-cases
 
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:app/core/infrastructure/http_client_helpers.dart';
 import 'package:app/features/authentification/core/infrastructure/authentification_api_client.dart';
 import 'package:app/features/profil/core/domain/utilisateur_id_non_trouve_exception.dart';
 import 'package:app/features/univers/core/domain/content_id.dart';
@@ -34,7 +34,7 @@ class UniversApiAdapter implements UniversPort {
     final response =
         await _apiClient.get(Uri.parse('/utilisateurs/$utilisateurId/univers'));
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération des univers'));
     }
 
@@ -64,7 +64,7 @@ class UniversApiAdapter implements UniversPort {
       ),
     );
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération des missions'));
     }
 
@@ -94,7 +94,7 @@ class UniversApiAdapter implements UniversPort {
       ),
     );
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (isResponseUnsuccessful(response.statusCode)) {
       return Left(Exception('Erreur lors de la récupération de la mission'));
     }
 
@@ -118,7 +118,7 @@ class UniversApiAdapter implements UniversPort {
       body: jsonEncode({'element_id': id.value}),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors du gain de points'));
   }
@@ -137,7 +137,7 @@ class UniversApiAdapter implements UniversPort {
       ),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? const Right(null)
         : Left(Exception('Erreur lors de la fin de la mission'));
   }
@@ -156,7 +156,7 @@ class UniversApiAdapter implements UniversPort {
       ),
     );
 
-    return response.statusCode == HttpStatus.ok
+    return isResponseSuccessful(response.statusCode)
         ? Right(
             (jsonDecode(response.body) as List<dynamic>)
                 .map((final e) => e as Map<String, dynamic>)


### PR DESCRIPTION
- Introduction des fonctions `isResponseSuccessful` et `isResponseUnsuccessful` pour rationaliser les vérifications de statut des réponses dans divers adaptateurs API.
- Mise à jour des implémentations existantes des adaptateurs API pour utiliser ces nouvelles fonctions d'aide afin d'améliorer la lisibilité et la maintenabilité.